### PR TITLE
Adds gerrit CLI script and some basic functions

### DIFF
--- a/bin/z-gerrit
+++ b/bin/z-gerrit
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+set -e
+
+. $Z_BASH_LIB/env.sh
+. $Z_BASH_LIB/gerrit.functions
+
+
+declare -r help_message="Usage: $(basename $0) [-d] [gerrit_command]
+  -h|--help - this help
+  -d|--debug - debug
+  gerrit_command - the command to execute via the gerrit SSH interface
+
+Executes the given gerrit command. Details about supported commands
+can be found in the documentation:
+https://gerrit.googlecode.com/svn/documentation/2.0/cmd-index.html"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -h|--help)
+      z_bash_help_stdout "$help_message"
+      exit 0
+    ;;
+    -d|--debug)
+      set -x
+    ;;
+    *)
+      break
+    ;;
+  esac
+  shift
+done
+
+declare -r gerrit_host=$(z_gerrit_host)
+
+if [ -n "$1" ]; then
+  declare -r gerrit_command="$@"
+else
+  declare -r gerrit_command="--help"
+fi
+
+gerrit_ssh $gerrit_host "$gerrit_command"

--- a/bin/z-review-comment
+++ b/bin/z-review-comment
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+set -e
+
+. $Z_BASH_LIB/env.sh
+. $Z_BASH_LIB/gerrit.functions
+. $Z_BASH_LIB/git.functions
+
+declare -r help_message="Usage: $(basename $0) [-d][-c commit] comment
+  -h|--help - this help
+  -c|--commit commitish - commit to comment on, defaults to last commit in repo
+  -d|--debug - debug
+
+Comment on a review"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -h|--help)
+      z_bash_help_stdout "$help_message"
+      exit 0
+    ;;
+    -c|--commit)
+      if [ -z "$2" ]; then
+        >&2 echo "Error: need a commit id"
+        z_bash_help_stderr "$help_message"
+        exit 1
+      fi
+      declare -r commit="$2"
+      shift
+    ;;
+    -d|--debug)
+      set -x
+      declare -r debug_flag="-d"
+    ;;
+    *)
+      break
+    ;;
+  esac
+  shift
+done
+
+if [ -z "$commit" ]; then
+  declare -r commit=$(z_git_last_commit)
+fi
+
+if [ -n "$@" ]; then
+  z_gerrit_comment $commit "$@" $debug_flag
+else
+  echo "ERROR: need some comments" >&2
+fi

--- a/bin/z-review-reviewer-add
+++ b/bin/z-review-reviewer-add
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+
+set -e
+
+. $Z_BASH_LIB/env.sh
+. $Z_BASH_LIB/gerrit.functions
+. $Z_BASH_LIB/git.functions
+
+declare -r help_message="Usage: $(basename $0) [-d] reviewer[s]
+  -h|--help - this help
+  -d|--debug - debug
+  -c|--commit commitish - commit to comment on, defaults to last commit in repo
+  reviewer[s] - people you want to add to the review
+
+Adds people to the review"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -h)
+      echo "$usage"
+      exit 0
+    ;;
+    -c|--commit)
+      if [ -z "$2" ]; then
+        >&2 echo "Error: need a commit id"
+        z_bash_help_stderr "$help_message"
+        exit 1
+      fi
+      declare -r commit="$2"
+      shift
+    ;;
+    -d)
+      set -x
+      declare -r debug_flag="-d"
+    ;;
+    *)
+      break
+    ;;
+  esac
+  shift
+done
+
+if [ -z "$commit" ]; then
+  declare -r commit=$(z_git_last_commit)
+fi
+
+if [ -n "$@" ]; then
+  for reviewer in $@; do
+    z_gerrit_reviewer_add $reviewer $commit $debug_flag
+  done
+else
+  echo "ERROR: need some reviewers, yo" >&2
+fi

--- a/lib/bash/bash.functions
+++ b/lib/bash/bash.functions
@@ -20,6 +20,14 @@ function z_bash_test_script() {
   bash -n "${path}"
 }
 
+function z_bash_help_stderr() {
+  >&2 echo "$1"
+} 
+
+function z_bash_help_stdout() {
+  echo "$1"
+} 
+
 function z_bash_check_scripts() {
   # Again checking the number of arguments passed in is equal to the number
   # expected and if not, will report to stderr the usage to aid debugging.
@@ -90,6 +98,8 @@ function z_bash_check_required_files_exist() {
 }
 
 if [ "${BASH_SOURCE[0]}" != "$0" ]; then
+  export -f z_bash_help_stdout
+  export -f z_bash_help_stderr
   export -f z_bash_test_script
   export -f z_bash_check_scripts
 else

--- a/lib/bash/bootstrap.sh
+++ b/lib/bash/bootstrap.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Purpose: provide a library of reusable bash related functions
+
+function z_path_add() {
+  local -r directory="$1"
+  local -r current_path="$PATH"
+  if [ -z "$current_path" ]; then
+    export "PATH=$directory"
+  else
+    if ! echo "$PATH" | grep -- "$directory" >/dev/null 2>&1; then
+      export "PATH=$directory:$PATH"
+    fi
+  fi
+}
+
+
+if [ "${BASH_SOURCE[0]}" != "$0" ]; then
+  if [ -z "$Z_HOME" ]; then
+    export -r Z_HOME=$(dirname $(dirname $(dirname $0)))
+    export -r Z_BIN=${Z_HOME}/bin
+    export -r Z_LIB=${Z_HOME}/lib
+    export -r Z_BASH_LIB=${Z_LIB}/bash
+    alias cd-="cd $Z_HOME"
+    alias cdb="cd $Z_BIN"
+    alias cdl="cd $Z_LIB"
+    z_path_add $Z_BIN
+  fi
+else
+  # I want to make sure we report to stderr that a library script that expects
+  # to be sourced by another script is being executed, not just sourced. Can
+  # also aid in debugging issues with your script.
+  >&2 echo "Error: executing ${0} intended to be sourced...nothing to do."
+  exit 1
+fi

--- a/lib/bash/env.sh
+++ b/lib/bash/env.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Purpose: provide minimal shared environment setup for zedtech bash scripts
+
+function z_env_setup_environment() {
+  declare -xr Z_TMP="${Z_TMP:-/tmp}"
+  # declare -xr Z_ETC="$Z_HOME/etc"
+  # declare -xr Z_VAR="${Z_VAR:-$Z_HOME/var}"
+  # declare -xr Z_ENV="${Z_ENV:-dev}"
+  # declare -xr Z_PLATFORM="$(uname -s)"
+  . $Z_BASH_LIB/bash.functions
+}
+
+function z_env_test_environment() {
+  if [ ! -d "$Z_HOME" -o ! -d "$Z_LIB" ]; then
+    >&2 echo "Error: Z_HOME (${Z_HOME}) and Z_LIB ($Z_LIB) are not directories"
+  fi
+}
+
+if [ "${BASH_SOURCE[0]}" != "$0" ]; then
+  z_env_setup_environment
+  z_env_test_environment
+else
+  >&2 echo "Error: executing ${0} intended to be sourced...nothing to do."
+  exit 1
+fi

--- a/lib/bash/gerrit.functions
+++ b/lib/bash/gerrit.functions
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Purpose: provide reusable gerrit related functions for shell scripts
+
+function gerrit_ssh() {
+  local -r gerrit_host="$1"
+  local -r gerrit_command="$2"
+  ssh -T -o BatchMode=yes ${gerrit_host} gerrit "$gerrit_command"
+}
+
+# ci stuff would use this too, like so:
+function z_gerrit_verify() {
+
+  local -r commit_id="$1"
+  local -r vote="$2"
+  local -r message="$3"
+  local -r debug="${4:-}"
+
+  z-gerrit $debug review --message "'$message'" --verified $vote -- $commit_id
+}
+
+function z_gerrit_comment() {
+  local -r commit_id="$1"
+  local -r comment="$2"
+  local -r debug="${3:-}"
+  z-gerrit $debug review --message "'$comment'" -- ${commit_id}
+}
+
+function z_gerrit_reviewer_add() {
+  local -r reviewer="$1"
+  local -r commit_id="$2"
+  local -r debug="${3:-}"
+  z-gerrit $debug set-reviewers --add ${reviewer} -- ${commit_id}
+}
+
+function z_gerrit_host() {
+  if [ -z "$Z_GERRIT_HOST" ]; then
+    local -r gerrit_host=$(git config --get remote.gerrit.url | sed 's/:.*//')
+    if [ -z "$gerrit_host" ]; then
+      >&2 echo "Error: can't find gerrit_host"
+      return 1
+    else
+      echo $gerrit_host
+    fi
+  else
+    echo "$Z_GERRIT_HOST"
+  fi
+}
+
+if [ "${BASH_SOURCE[0]}" != "$0" ]; then
+  export -f z_gerrit_comment
+  export -f z_gerrit_host
+  export -f z_gerrit_reviewer_add
+  export -f z_gerrit_verify
+else
+  >&2 echo "Error: executing ${0} intended to be sourced...nothing to do."
+  exit 1
+fi

--- a/lib/bash/git.functions
+++ b/lib/bash/git.functions
@@ -18,6 +18,27 @@ function z_git_changed_files() {
   git diff-index --diff-filter="${filter}" --name-only --cached "${remote}/${branch}" -- "${subdir}"
 }
 
+# how far do we want to go with wrapping? (should users be able to run these
+# commands against multiple gerrit repos and it can determine context?
+# should we wrap the commit process like git flow does?)
+# function z_git_repo_root() {}
+# function z_git_check_local_commits() {
+# function z_git_check_untracked() {
+
+function z_git_current_branch() {
+  git rev-parse --abbrev-ref HEAD
+}
+
+function z_git_last_commit() {
+  declare -r commit_id=$(git log | head -1 | awk '{ print $2 }')
+  if [ -z "$commit_id" ]; then
+    >&2 echo "Error: unable to find last commit"
+    return 1
+  else
+    echo "$commit_id"
+  fi
+}
+
 function z_git_removed_files() {
   z_git_changed_files "${1:-.}" "D" "${2:-origin}" "${3:-master}"
 }
@@ -39,6 +60,7 @@ function z_git_clean_clone_workspace() {
 }
 
 if [ "${BASH_SOURCE[0]}" != "$0" ]; then
+  export -f z_git_last_commit
   export -f z_git_changed_files
   export -f z_git_removed_files
   export -f z_git_added_files


### PR DESCRIPTION
Adds gerrit CLI script and some basic functions like:
- add reviewers to a review
- comment on a review

Need feedback on path for z-gerrit/z-review, specifically:
- do we want to abstract this further so z-review knows nothing
  about gerrit and only uses some sort of lib/bash/review.functions
  that talks to gerrit
- do we want to support doing stuff outside the repo by ID only?
- don't think we need it now, but having OWNERS support would be
  awesome, discuss
- should we add functionality that wraps the add/commit process
  too? like git flow 'can' do (protects engineers who can't seem
  to ever remember to rebase first and always ask why they are
  stuck in recursive merge land)
